### PR TITLE
Fix building on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 _ = Package(name: "antimony",
             platforms: [
-              .macOS(.v12),
+              .macOS(.v13),
             ],
             products: [
               .executable(name: "sb", targets: ["sb"])

--- a/Sources/antimony/Configuration/Label.swift
+++ b/Sources/antimony/Configuration/Label.swift
@@ -1,7 +1,6 @@
 // Copyright © 2024 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-import WinSDK
 import struct Foundation.URL
 
 /// A label is a unique identifier for a BUILD entity.

--- a/Sources/antimony/JobEmitter.swift
+++ b/Sources/antimony/JobEmitter.swift
@@ -49,6 +49,12 @@ public struct JobEmitter {
 #elseif arch(x86_64)
     let triple: String = "x86_64-unknown-linux-gnu"
 #endif
+#elseif os(macOS)
+#if arch(arm64)
+    let triple: String = "arm64-apple-macosx13.0"
+#elseif arch(x86_64)
+    let triple: String = "x86_64-apple-macosx13.0"
+#endif
 #endif
 
     let module: RelativePath =


### PR DESCRIPTION
- The WinSDK module doesn't exist, of course. It isn't used; the import can just go.
- Triple wasn't defined.
- Some string functions require macOS 13. Instead of adding `@available` everywhere, I just bumped the minimum supported macOS version to 13.
- Added SDK path to the arguments supplied to the driver. It needs that for Darwin toolchains.

There are some other missing pieces (e.g. `placeholder.json`) before it's possible for people to run their own experiments and attempt to replicate your findings, but with this it's at least possible to compile and execute the tool on macOS. 